### PR TITLE
wolne_reputy - unused_reput on top ever site.

### DIFF
--- a/events/managers.py
+++ b/events/managers.py
@@ -132,7 +132,7 @@ class BetManager(models.Manager):
 
         user.total_cash -= bought_for_total
         user.portfolio_value += bought_for_total
-        user.save(update_fields=['total_cash'])
+        user.save()
 
         event.increment_quantity(for_outcome, by_amount=quantity)
         """ Increment turnover only for buying bets """

--- a/templates/logged_in.html
+++ b/templates/logged_in.html
@@ -33,7 +33,7 @@
 			<a href="#">
 			<div class="lewa stats">
 				<p>wolne reputy</p>
-				<p class="freevalue">{{ user.total_cash_formatted }}</p>
+				<p class="freevalue">{{ user.unused_reput }}</p>
 			</div>
 			</a>
 


### PR DESCRIPTION
Usunąłem parametr update_fields=['total_cash'] metody save() ponieważ to powodowało zapisanie tylko total_cash w bazie. Nie rozumiem dlaczego ktoś ustawił. Po tej zmianie operacja kupna lub sprzedaży zapisuje przeliczoną wartość portfolio_value  w bazie i już nie powraca do poprzedniego stanu po przeładowaniu strony, tak jak to widzieliśmy ostatnio.
Ustawiłem, że tam gdzie jest napisane "wolne reputy" wyświetla się wartość unused_reput. Dobrze?
