### PR TITLE
Bugfix/sticky-header-avatar-skipping

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -26,7 +26,7 @@ b {font-weight: 700;}
 
  /* transitions */
 /*0,15 sek*/
-#maintop, #maintop .sm-bg, #maintop .graj .prawa, #maintop nav ul, #maintop nav ul li, #maintop .socialmedia, #maintop .logo div, #maintop .avatar img, #maintop .userdata, #maintop .userdata .wallet, #maintop nav ul .burger,
+#maintop .sm-bg, #maintop .graj .prawa, #maintop nav ul, #maintop nav ul li, #maintop .socialmedia, #maintop .logo div, #maintop .avatar img, #maintop .userdata, #maintop .userdata .wallet, #maintop nav ul .burger,
 .overlay, .betresult, #wallet-not .container,
 #login div, #login aside, #login, #login .przycisk,
 #featured .details,


### PR DESCRIPTION
Hi
*Symptoms*:
The height of the #maintop container gets changed for the .sticktotop action when scrolling down.
When scrolling up, the transition makes the avatar picture to skip from left to right very fast it breaks the app experience. 
I guess the skipping is due he logo height change. 
*Fix*:
remove transition from the maintop container. This fixes it, it changes the header behaviour a little bit, but looks much more acceptable. 

*Possible refactor*
the logo can be wrapped inside some container with defined height and `overflow-y: visible`, etc.